### PR TITLE
QueryData method returns error due to improper http headers

### DIFF
--- a/domo/datasets.go
+++ b/domo/datasets.go
@@ -501,7 +501,8 @@ func (s *DatasetsService) DownloadDatasetCSV(ctx context.Context, id string, inc
 	return csv, resp, nil
 }
 
-// QueryData takes a sql query and uses it to return a string csv of the query table results for the dataset.
+// QueryData takes a sql query and uses it to return a json string of the query table results for the dataset.
+// see https://developer.domo.com/docs/dataset-api-reference/dataset#Query%20a%20DataSet for an example response.
 func (s *DatasetsService) QueryData(ctx context.Context, id, sqlQuery string) (string, *http.Response, error) {
 	u := fmt.Sprintf("v1/datasets/query/execute/%s", id)
 	b := struct {
@@ -511,7 +512,10 @@ func (s *DatasetsService) QueryData(ctx context.Context, id, sqlQuery string) (s
 	if err != nil {
 		return "", nil, err
 	}
-	req.Header.Set("Accept", "text/csv")
+
+	// This API endpoint doesn't return a CSV, but it returns a JSON object with the query results and some metadata.
+	// see https://developer.domo.com/docs/dataset-api-reference/dataset#Query%20a%20DataSet for an example response.
+	req.Header.Set("Accept", "application/json")
 
 	buf := new(bytes.Buffer)
 	resp, err := s.client.Do(ctx, req, nil)

--- a/domo/datasets_test.go
+++ b/domo/datasets_test.go
@@ -306,8 +306,8 @@ func TestDatasetsService_QueryData(t *testing.T) {
 	client := auth.NewClient()
 	ctx := context.Background()
 
-	sqlQuery := fmt.Sprintf("SELECT %s FROM table WHERE `WMS Community`='%s'", "`Lot No. for Community Maps`, `Sales Status Series for Community Map`, `Sales Status`", "ABM")
-	data, _, err := client.Datasets.QueryData(ctx, "447a2858-9c1c-42a9-b90b-a5340268d90e", sqlQuery)
+	sqlQuery := fmt.Sprintf("SELECT %s FROM table WHERE `GL Account No.`=%s", "`GL Account No.`, `Category`", "1000")
+	data, _, err := client.Datasets.QueryData(ctx, "5a60b561-7030-42fa-a8f6-d04ddbe89864", sqlQuery)
 	if err != nil {
 		t.Errorf("Unexpected Error Retrieving Data: %s", err)
 	}


### PR DESCRIPTION
Fixes #1

Updates http header, adds a note about it.

Updates QueryData test to work with current test instance